### PR TITLE
Added short sleep for rosbag subprocess to clean up after being closed

### DIFF
--- a/dvrk_data_collect.py
+++ b/dvrk_data_collect.py
@@ -50,6 +50,8 @@ def terminate_process_and_children(p):
     for pid_str in ps_output.split("\n")[:-1]:
             os.kill(int(pid_str), signal.SIGINT)
     p.terminate()
+    #wait for rosbag to clean up
+    rospy.sleep(1)
 
 if sys.version_info.major < 3:
     input = raw_input
@@ -179,6 +181,5 @@ terminate_process_and_children(rosbag_process)
 
 print('\n--> Time to replay trajectory: %f seconds' % (time.time() - start_time))
 print('--> Done!')
-
 # check if required topics are collected correctly
 os.system(sanity_cmd)


### PR DESCRIPTION
Was getting file not exist error from the sanity check. Think it is due to a timing issue with the rosbag subprocess not fully cleaning up before getting to the sanity check.

Tried doing a while p.poll() loop to properly wait on the subprocess but didn't work. Just threw a short sleep after the terminate signal instead. 

Adds a second to the runtime, but don't have to manually sanity check. 